### PR TITLE
Changes required to make QLF work with the new quicklook configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,23 +48,7 @@
     desi_quicklook --help
     ```
 
-4. Get test data
-
-    ```
-    export DESI_SPECTRO_DATA=$QLF_ROOT/data
-    mkdir -p $DESI_SPECTRO_DATA
-    cd $DESI_SPECTRO_DATA
-    
-    # Test data for local run of QLF: night 20170428, exposures 3,4 and all cameras
-    wget -c http://portal.nersc.gov/project/desi/data/quicklook/20170428_small.tar.gz
-    tar xvzf 20170428.tar.gz
-    ```
-    
-    NOTE: on `desidev@lbl.gov`, you might copy ~1 night of data from `/home/angelofausti/data/20170428.tgz`
-
-### Running QLF 
-
-1. Configure QLF 
+4. Configure QLF
 
     Activate the `quicklook` environment
     
@@ -86,7 +70,24 @@
     NOTE: in development mode, QLF will process the data specified in the `qlf.cfg`. 
     Each time you run QLF a fresh database is created and the Quick Look outputs are ingested at the end of the processing of each exposure. 
 
-2. Start QLF  
+5. Get test data
+
+    ```
+    export DESI_SPECTRO_DATA=<input data directory configured in step 4>
+    mkdir -p $DESI_SPECTRO_DATA
+    cd $(dirname $DESI_SPECTRO_DATA)
+
+    # Test data for local run of QLF: night 20170428, exposures 3,4 and all cameras
+    wget -c http://portal.nersc.gov/project/desi/data/quicklook/20170428_small.tar.gz
+    tar xvzf 20170428.tar.gz
+    ```
+
+    NOTE: on `desidev@lbl.gov`, you might copy ~1 night of data from `/home/angelofausti/data/20170428.tgz`
+
+
+### Running QLF
+
+1. Start QLF
 
     ```
     cd $QLF_ROOT/qlf/qlf

--- a/README.md
+++ b/README.md
@@ -50,13 +50,7 @@
 
 4. Configure QLF
 
-    Activate the `quicklook` environment
-    
-    ```
-    source ~/miniconda3/bin/activate quicklook
-    export QLF_ROOT=$HOME/quicklook
-    ```
-    
+   
     Create your `qlf.cfg` file
 
     ```
@@ -87,8 +81,15 @@
 
 ### Running QLF
 
-1. Start QLF
 
+1. Activate the `quicklook` environment
+    
+    ```
+    source ~/miniconda3/bin/activate quicklook
+    export QLF_ROOT=$HOME/quicklook
+    ```
+
+2. Start QLF
     ```
     cd $QLF_ROOT/qlf/qlf
     ./run.sh

--- a/bin/dos_monitor.py
+++ b/bin/dos_monitor.py
@@ -12,7 +12,7 @@ class DOSmonitor(object):
         self.cfg = configparser.ConfigParser()
         try:
             self.cfg.read('%s/qlf/config/qlf.cfg' % qlf_root)
-            self.datadir = os.path.normpath(self.cfg.get('namespace', 'datadir'))
+            self.desi_spectro_data = os.path.normpath(self.cfg.get('namespace', 'desi_spectro_data'))
         except Exception as error:
             print(error)
             print("Error reading  %s/qlf/config/qlf.cfg" % qlf_root)
@@ -75,7 +75,7 @@ class DOSmonitor(object):
             "night": night,
             "expid": exposure,
             "zfill": str(exposure).zfill(8),
-            "data_dir": self.datadir,
+            "desi_spectro_data": self.desi_spectro_data,
             "cameras": camera_list
         }
 

--- a/bin/dos_monitor.py
+++ b/bin/dos_monitor.py
@@ -30,12 +30,11 @@ class DOSmonitor(object):
 
         exposures_list = list()
 
-        calib = self.cfg.get("data", "calib")
         exposures = self.cfg.get("data", "exposures").split(',')
 
         for expid in exposures:
             try:
-                exposure = self.get_exposure(night, expid, calib)
+                exposure = self.get_exposure(night, expid)
                 exposures_list.append(exposure)
             except Exception as error:
                 print(error)
@@ -60,23 +59,15 @@ class DOSmonitor(object):
 
         return cameras
 
-    def get_exposure(self, night, exposure, calib):
+    def get_exposure(self, night, exposure):
         """ Gets all data of a determinate exposure. """
 
         camera_list = list()
 
         for camera in self.cameras:
-            try:
-                fiberflat = self.get_fiberflat_file(night, calib, camera)
-                psfboot = self.get_psfboot_file(night, camera)
-            except Exception as error:
-                print(error)
-                continue
 
             camera_dict = {
                 "name": camera,
-                "psfboot": psfboot,
-                "fiberflat": fiberflat
             }
             camera_list.append(camera_dict)
 
@@ -87,35 +78,6 @@ class DOSmonitor(object):
             "data_dir": self.datadir,
             "cameras": camera_list
         }
-
-    def get_fiberflat_file(self, night, calib, camera):
-        """ Gets the fiberflat file by camera """
-
-        path = os.path.join(self.datadir, night)
-        calib = str(calib).zfill(8)
-
-        pattern = "(fiberflat-%s-%s.fits)" % (camera, calib)
-        regex = re.compile(pattern)
-
-        for f in os.listdir(path):
-            if regex.search(f):
-                return os.path.join(path, f)
-
-        raise OSError(2, 'fiberflat not found', pattern)
-
-    def get_psfboot_file(self, night, camera):
-        """ Gets the psfboot file by camera """
-
-        path = os.path.join(self.datadir, night)
-
-        pattern = "(psfboot-%s.fits)" % camera
-        regex = re.compile(pattern)
-
-        for f in os.listdir(path):
-            if regex.search(f):
-                return os.path.join(path, f)
-
-        raise OSError(2, 'psfboot not found', pattern)
 
 if __name__ == "__main__":
 

--- a/bin/qlf_daemon.py
+++ b/bin/qlf_daemon.py
@@ -66,7 +66,6 @@ class QLFRun(Process):
 
                 ql = QLFPipeline(exposure)
                 ql.start_process()
-                logger.info('Executing expid %s...' % exposure.get('expid'))
 
             self.last_night = night
 

--- a/bin/qlf_models.py
+++ b/bin/qlf_models.py
@@ -179,44 +179,4 @@ class QLFModels(object):
 if __name__=='__main__':
     qlf = QLFModels()
 
-# TODO: implement command line interface for qlf_models.py
-# if __name__=='__main__':
-#
-#     parser = argparse.ArgumentParser(
-#         description="""Upload QA metrics produced by the Quick Look pipeline to QLF database.
-# This script is meant to be run from the command line or imported by Quick Look. """,
-#         formatter_class=argparse.RawDescriptionHelpFormatter)
-#
-#     parser.add_argument(
-#             '--file',
-#             dest='file',
-#             required=True,
-#             help='Path to QA file produced by Quick Look')
-#
-#     parser.add_argument(
-#             '--qa-name',
-#             dest='qa_name',
-#             required=True,
-#             help='Name of the QA metric to be ingested'
-#     )
-#
-#     parser.add_argument(
-#             '--force',
-#             default=False,
-#             action='store_true',
-#             help='Overwrite QA results for a given metric'
-#     )
-#
-#     qa_name = parser.parse_args().qa_name
-#
-#     file = parser.parse_args().file
-#
-#     job_name = os.path.basename(file)
-#
-#     results = yaml.load(open(file, 'r'))
-#
-#     force = parser.parse_args().force
-#
-#     qlfi = QLFIngest()
-#
-#     qlfi.post(qa_name, job_name, results, force)
+

--- a/bin/qlf_pipeline.py
+++ b/bin/qlf_pipeline.py
@@ -15,6 +15,7 @@ cfg = configparser.ConfigParser()
 
 try:
     cfg.read('%s/qlf/config/qlf.cfg' % qlf_root)
+    qlconfig = cfg.get('main', 'qlconfig')
     scratch = cfg.get('namespace', 'scratch')
 except Exception as error:
     print(error)
@@ -151,16 +152,13 @@ class QLFPipeline(object):
         """ Execute QL Pipeline by camera """
 
         cmd = (
-            'desi_quicklook -n {night} -c {camera} -e {exposure} '
-            '-f dark --psfboot {psfboot} --fiberflat {fiberflat} '
+            'desi_quicklook -i {qlconfig} -n {night} -c {camera} -e {exposure} '
             '--rawdata_dir {data_dir} --specprod_dir {scratch} '
-            '--save qlconfig-{camera}-{exposure}'
         ).format(**{
+            'qlconfig': qlconfig,
             'night': self.data.get('night'),
-            'exposure': str(self.data.get('expid')),
             'camera': camera.get('name'),
-            'psfboot': camera.get('psfboot'),
-            'fiberflat': camera.get('fiberflat'),
+            'exposure': str(self.data.get('expid')),
             'data_dir': self.data.get('data_dir'),
             'scratch': scratch
         })

--- a/bin/qlf_pipeline.py
+++ b/bin/qlf_pipeline.py
@@ -257,22 +257,3 @@ class QLFPipeline(object):
         expid = self.data.get('expid')
         return self.models.get_expid_in_process(expid)
 
-
-if __name__ == "__main__":
-    exposure = {
-        'night': '20170428',
-        'expid': '3',
-        'zfill': '00000003',
-        'desi_spectro_data': '/home/singulani/raw_data',
-        'cameras': [
-          {
-            'name': 'r8',
-          },
-          {
-            'name': 'r9',
-          }
-        ]
-    }
-
-    qlp = QLFPipeline(exposure)
-    qlp.start_process()

--- a/config/qlf.cfg.template
+++ b/config/qlf.cfg.template
@@ -19,12 +19,13 @@ loglevel=INFO
 # the progress of the data reduction
 logfile=
 
+# configuration file for the quick look pipeline
+qlconfig=
+
+
 [data]
 # Which night to process? we do not support a list of nights yet.
 night=20170428
-
-# calibration exposure id to be used, e.g. fiberflat-b0-00000001.fits
-calib=1
 
 # exposure ids to be processed, e.g. desi-00000003.fits.fz, desi-00000004.fits.fz
 exposures=3,4

--- a/config/qlf.cfg.template
+++ b/config/qlf.cfg.template
@@ -20,6 +20,7 @@ loglevel=INFO
 logfile=
 
 # configuration file for the quick look pipeline
+# e.g. $QLF_ROOT/desispec/py/desispec/data/quicklook/qlconfig_dark.yaml
 qlconfig=
 
 

--- a/config/qlf.cfg.template
+++ b/config/qlf.cfg.template
@@ -44,9 +44,9 @@ arms=b,r,z
 spectrographs=0,1
 
 [namespace]
-# Input data directory, e.g. $QLF_ROOT/data
-datadir=
+# Input data directory, e.g. $DESI_SPECTRO_DATA
+desi_spectro_data=
 
-# Processing output, e.g. $QLF_ROOT/outputs or some other local (fast) scratch area
+# Processing output, e.g. $DESI_SPECTRO_REDUX or some other local (fast) scratch area
 # Note: this directory is created by QLF if it does not exist.
-scratch=
+desi_spectro_redux=

--- a/qlf/dashboard/bokeh/monitor/main.py
+++ b/qlf/dashboard/bokeh/monitor/main.py
@@ -14,7 +14,7 @@ cfg = configparser.ConfigParser()
 
 try:
     cfg.read('%s/qlf/config/qlf.cfg' % qlf_root)
-    scratch = cfg.get('namespace', 'scratch')
+    desi_spectro_redux = cfg.get('namespace', 'desi_spectro_redux')
 except Exception as error:
     logger.error(error)
     logger.error("Error reading  %s/qlf/config/qlf.cfg" % qlf_root)
@@ -96,7 +96,7 @@ def update(t):
             try:
                 for item in PROCESS.get("jobs", list()):
                     if cam == item.get("camera"):
-                        cameralog = os.path.join(scratch, item.get('logname'))
+                        cameralog = os.path.join(desi_spectro_redux, item.get('logname'))
                         break
                 if cameralog:
                     arq = open(cameralog, 'r')


### PR DESCRIPTION
* QLF is now working with the new quicklook configuration format (see desispec ql_config_new branch). Now there is a key in the qlf.cfg pointing to the quicklook configuration file which is fixed, independent of the night, exposure and camera processed.

* In recent changes the quicklook pipeline I/O was significantly reduced. Now it produces just one frame file for each camera in the output directory. These files are now 16M,  before we had 4 files of ~120M for each camera. Also, the pix files 116M each are not being created anymore. 

As a result of that, the processing of 30 cameras in parallel takes 8 min on desidev compared to the 15 min we had before.

NOTE: processing just one camera takes about 3 min, we still have some overhead in the parallel processing to be investigated.

* Renamed variables and keys in qlf.cfg to make it more complaint with DESI datamodel, using DESI_SPECTRO_DATA and DESI_SPECTRO_REDUX now.

* Improved the data ingestion. All QA results for the 30 cameras are bein ingested in 1min50s using sqlite3 (before it was 5 min). Surprisingly it takes about the same time using postgresQL, 1min 30s.

We did some tests and verified that reading YAML files is slow, as pointed out by Stephen. 

YAML dump duration:  13.794826381839812 seconds
JSON dump duration:  2.4137240648269653 seconds
YAML load duration:  23.01600768789649 seconds
JSON load duration:  0.6193110221065581 seconds

If needed, we can reduce further the ingestion time writing quicklook QA results in JSON format instead of YAML.

QLF branch ql_config_new is compatible with quicklook branch ql_config_new. 

It would be great if we could merge that to master so that we have a working version of QLF + quicklook.   Right now QLF+quicklook on master is not working. 